### PR TITLE
Fixes an issue not handling paths containing a space

### DIFF
--- a/start_server.bat
+++ b/start_server.bat
@@ -25,7 +25,7 @@ echo my_path: %~dp0
 @REM set current_dir=
 set VENV_DIR=%~dp0server_env
 @REM cd ./server_env/Scripts/
-set PYTHON=%VENV_DIR%\Scripts\Python.exe
+set PYTHON="%VENV_DIR%\Scripts\Python.exe"
 %PYTHON% -m pip install -r requirements.txt
 
 cd ./server/python_server


### PR DESCRIPTION
Batch file won't run properly if there the path contains a space.

For example, if the path is `C:\Stable Diffusion` it will break when trying to run Python, specifically on line 29. With this change, the referenced Python path is enclosed in quotations to support paths containing a space. I suppose this will also fix the batch file not running for paths with certain special characters that are reserved characters for cmd.