### PR TITLE
export and import using unique name

### DIFF
--- a/index.js
+++ b/index.js
@@ -484,8 +484,14 @@ document
 async function setInitImage () {
   // await exportHelper.exportPng()
   try {
+    const layer = await app.activeDocument.activeLayers[0]
+    old_name = layer.name 
     await psapi.exportPng(random_session_id)
-    image_name = await app.activeDocument.activeLayers[0].name
+    
+    image_name = psapi.layerNameToFileName(old_name,layer.id,random_session_id)
+    
+    // image_name = psapi.layerToFileName(layer,random_session_id)
+
     image_name = `${image_name}.png`
     g_init_image_name = image_name
     console.log(image_name)
@@ -500,19 +506,25 @@ document.getElementById('bSetInitImage').addEventListener('click', setInitImage)
 
 async function setInitImageMask () {
   try {
-    // await exportHelper.exportPng()
+    const layer = await app.activeDocument.activeLayers[0]
+    old_name = layer.name 
     await psapi.exportPng(random_session_id)
-
+    image_name = psapi.layerNameToFileName(old_name,layer.id,random_session_id)
+    
     //get the active layer name
-    image_name = await app.activeDocument.activeLayers[0].name
+    // const layer = await app.activeDocument.activeLayers[0]
+    // image_name = psapi.layerToFileName(layer,random_session_id)
     image_name = `${image_name}.png`
+    
     g_init_image_mask_name = image_name
     console.log(image_name)
+    
     const image_src = await sdapi.getInitImage(g_init_image_mask_name)
     const ini_image_mask_element = document.getElementById('init_image_mask')
     ini_image_mask_element.src = image_src
   } catch (e) {
-    console.log('setInitImageMask error:', e)
+    
+    console.error(`setInitImageMask error: ${e}`)
   }
 }
 document

--- a/psapi.js
+++ b/psapi.js
@@ -256,66 +256,67 @@ async function unSelectMarqueeExe () {
 ////selection:
 
 async function selectLayerChannelCommand () {
-//   const result = await batchPlay(
-//     [
-//       {
-//         _obj: 'set',
-//         _target: [
-//           {
-//             _ref: 'channel',
-//             _property: 'selection'
-//           }
-//         ],
-//         to: {
-//           _ref: [
-//             {
-//               _ref: 'channel',
-//               _enum: 'channel',
-//               _value: 'transparencyEnum'
-//             },
-//             {
-//               _ref: 'layer',
-//               _name: 'Group 5'
-//             }
-//           ]
-//         },
-//         _options: {
-//           dialogOptions: 'dontDisplay'
-//         }
-//       }
-//     ],
-//     {
-//       synchronousExecution: false,
-//       modalBehavior: 'execute'
-//     }
-//   )
-const batchPlay = require("photoshop").action.batchPlay;
+  //   const result = await batchPlay(
+  //     [
+  //       {
+  //         _obj: 'set',
+  //         _target: [
+  //           {
+  //             _ref: 'channel',
+  //             _property: 'selection'
+  //           }
+  //         ],
+  //         to: {
+  //           _ref: [
+  //             {
+  //               _ref: 'channel',
+  //               _enum: 'channel',
+  //               _value: 'transparencyEnum'
+  //             },
+  //             {
+  //               _ref: 'layer',
+  //               _name: 'Group 5'
+  //             }
+  //           ]
+  //         },
+  //         _options: {
+  //           dialogOptions: 'dontDisplay'
+  //         }
+  //       }
+  //     ],
+  //     {
+  //       synchronousExecution: false,
+  //       modalBehavior: 'execute'
+  //     }
+  //   )
+  const batchPlay = require('photoshop').action.batchPlay
 
-const result = await batchPlay(
-[
-   {
-      _obj: "set",
-      _target: [
-         {
-            _ref: "channel",
-            _property: "selection"
-         }
-      ],
-      to: {
-         _ref: "channel",
-         _enum: "channel",
-         _value: "transparencyEnum"
-      },
-      _options: {
-         dialogOptions: "dontDisplay"
+  const result = await batchPlay(
+    [
+      {
+        _obj: 'set',
+        _target: [
+          {
+            _ref: 'channel',
+            _property: 'selection'
+          }
+        ],
+        to: {
+          _ref: 'channel',
+          _enum: 'channel',
+          _value: 'transparencyEnum'
+        },
+        _options: {
+          dialogOptions: 'dontDisplay'
+        }
       }
-   }
-],{
-   synchronousExecution: false,
-   modalBehavior: "execute"
-});
+    ],
+    {
+      synchronousExecution: false,
+      modalBehavior: 'execute'
+    }
+  )
 }
-
 
 async function getSelectionInfoCommand () {
   const result = await batchPlay(
@@ -414,111 +415,141 @@ async function reSelectMarqueeExe (selectionInfo) {
   })
 }
 
+async function snapshot_layer () {
+  let result
+  let psAction = require('photoshop').action
+  ids = app.activeDocument.activeLayers.map(layer => layer.id)
+  let command = [
+    // Select All Layers current layer
+    {
+      _obj: 'selectAllLayers',
+      _target: [{ _enum: 'ordinal', _ref: 'layer', _value: 'targetEnum' }]
+    },
+    // Duplicate current layer
+    // {"ID":[459,460,461,462,463,464,465,466,467,468,469,470,471,472,473,474,475,476,477,478,479,480,481,482,483,484,485,486,487,488,489,490,491,492,493,494,495,496,497,498,499,500,501,502,503,504,505,506,507,508,509,510,511,512,513],"_obj":"duplicate","_target":[{"_enum":"ordinal","_ref":"layer","_value":"targetEnum"}],"version":5},
+    {
+      ID: ids,
+      _obj: 'duplicate',
+      _target: [{ _enum: 'ordinal', _ref: 'layer', _value: 'targetEnum' }],
+      version: 5
+    },
 
+    // Merge Layers
+    { _obj: 'mergeLayersNew' },
+    // Make
+    {
+      _obj: 'make',
+      at: { _enum: 'channel', _ref: 'channel', _value: 'mask' },
+      new: { _class: 'channel' },
+      using: { _enum: 'userMaskEnabled', _value: 'revealSelection' }
+    },
+    // Set Selection
+    {
+      _obj: 'set',
+      _target: [{ _property: 'selection', _ref: 'channel' }],
+      to: { _enum: 'ordinal', _ref: 'channel', _value: 'targetEnum' }
+    }
+  ]
+  result = await psAction.batchPlay(command, {})
+  return result
+}
 
-async function snapshot_layer() {
-    let result;
-    let psAction = require("photoshop").action;
-    ids = app.activeDocument.activeLayers.map(layer => layer.id)
-    let command = [
-        // Select All Layers current layer
-        {"_obj":"selectAllLayers","_target":[{"_enum":"ordinal","_ref":"layer","_value":"targetEnum"}]},
-        // Duplicate current layer
-        // {"ID":[459,460,461,462,463,464,465,466,467,468,469,470,471,472,473,474,475,476,477,478,479,480,481,482,483,484,485,486,487,488,489,490,491,492,493,494,495,496,497,498,499,500,501,502,503,504,505,506,507,508,509,510,511,512,513],"_obj":"duplicate","_target":[{"_enum":"ordinal","_ref":"layer","_value":"targetEnum"}],"version":5},
-        {"ID":ids,"_obj":"duplicate","_target":[{"_enum":"ordinal","_ref":"layer","_value":"targetEnum"}],"version":5},
-
-        // Merge Layers
-        {"_obj":"mergeLayersNew"},
-        // Make
-        {"_obj":"make","at":{"_enum":"channel","_ref":"channel","_value":"mask"},"new":{"_class":"channel"},"using":{"_enum":"userMaskEnabled","_value":"revealSelection"}},
-        // Set Selection
-        {"_obj":"set","_target":[{"_property":"selection","_ref":"channel"}],"to":{"_enum":"ordinal","_ref":"channel","_value":"targetEnum"}}
-    ];
-    result = await psAction.batchPlay(command, {});
-    return result
-  }
-
-async function snapshot_layerExe() {
-    await require("photoshop").core.executeAsModal(snapshot_layer, {"commandName": "Action Commands"});
+async function snapshot_layerExe () {
+  await require('photoshop').core.executeAsModal(snapshot_layer, {
+    commandName: 'Action Commands'
+  })
 }
 
 // await runModalFunction();
 
-
-async function fillAndGroup() {
-  let result;
-  let psAction = require("photoshop").action;
+async function fillAndGroup () {
+  let result
+  let psAction = require('photoshop').action
 
   // let newCommand =[
   //   // snapshotLayer
-    
+
   //   // makeGroupCommand
 
   //   // Make fill layer
   //   {"_obj":"make","_target":[{"_ref":"contentLayer"}],"using":{"_obj":"contentLayer","type":{"_obj":"solidColorLayer","color":{"_obj":"RGBColor","blue":255.0,"grain":255.0,"red":255.0}}}},
 
   // ]
-  
+
   let command = [
     // Make fill layer
-    {"_obj":"make","_target":[{"_ref":"contentLayer"}],"using":{"_obj":"contentLayer","type":{"_obj":"solidColorLayer","color":{"_obj":"RGBColor","blue":255.0,"grain":255.0,"red":255.0}}}},
+    {
+      _obj: 'make',
+      _target: [{ _ref: 'contentLayer' }],
+      using: {
+        _obj: 'contentLayer',
+        type: {
+          _obj: 'solidColorLayer',
+          color: { _obj: 'RGBColor', blue: 255.0, grain: 255.0, red: 255.0 }
+        }
+      }
+    }
     // Move current layer
     // {"_obj":"move","_target":[{"_enum":"ordinal","_ref":"layer","_value":"targetEnum"}],"adjustment":false,"layerID":[17],"to":{"_index":7,"_ref":"layer"},"version":5},
     // Select layer “Layer 4 copy”
     // {"_obj":"select","_target":[{"_name":"Layer 4 copy","_ref":"layer"}],"layerID":[17,15],"makeVisible":false,"selectionModifier":{"_enum":"selectionModifierType","_value":"addToSelectionContinuous"}},
     // Make Group
     // {"_obj":"make","_target":[{"_ref":"layerSection"}],"from":{"_enum":"ordinal","_ref":"layer","_value":"targetEnum"},"layerSectionEnd":19,"layerSectionStart":18,"name":"Group 1"}
-  ];
+  ]
   const snapshotLayer = await app.activeDocument.activeLayers[0]
   await makeGroupCommand()
   const groupLayer = app.activeDocument.activeLayers[0]
-  result = await psAction.batchPlay(command, {});
+  result = await psAction.batchPlay(command, {})
   const fillLayer = app.activeDocument.activeLayers[0]
   snapshotLayer.moveAbove(fillLayer)
   // await app.activeDocument.activeLayers[0].moveAbove()
   // const layerIDs = []
   // const to_index = await getIndexCommand(groupLayer.id)
   // await moveToGroupCommand(to_index, layerIDs)
-  
 }
 
-async function fillAndGroupExe() {
-  await require("photoshop").core.executeAsModal(fillAndGroup, {"commandName": "Action Commands"});
+async function fillAndGroupExe () {
+  await require('photoshop').core.executeAsModal(fillAndGroup, {
+    commandName: 'Action Commands'
+  })
 }
-async function fastSnapshot(){
+async function fastSnapshot () {
   await snapshot_layerExe()
   await fillAndGroupExe()
 }
 
-
-
-
-function layerToFileName(layer,session_id){
+function layerToFileName (layer, session_id) {
   file_name = `${layer.name}_${layer.id}_${session_id}`
   return file_name
 }
+function layerNameToFileName(layer_name,layer_id,session_id)
+{
+  file_name = `${layer_name}_${layer_id}_${session_id}`
+  return file_name
 
+}
 async function exportPngCommand (session_id) {
-  
   // const result = await batchPlay { _obj: “exportSelectionAsFileTypePressed”}
 
   // const destFolder = (await storage.localFileSystem.getDataFolder()).nativePath;
   const storage = require('uxp').storage
   const fs = storage.localFileSystem
-  
-        let pluginFolder = await fs.getPluginFolder()
-        // await fs.getFolder("./init_images")
-        let init_images_dir = await pluginFolder.getEntry("./server/python_server/init_images")
-        const layer =  await app.activeDocument.activeLayers[0]
-        const old_name = layer.name
-        //change the name of layer to unique name 
-        const file_name = layerToFileName(layer,session_id)
-        layer.name = file_name
-        const id = await app.activeDocument.activeLayers[0].id     
+
+  let pluginFolder = await fs.getPluginFolder()
+  // await fs.getFolder("./init_images")
+  let init_images_dir = await pluginFolder.getEntry(
+    './server/python_server/init_images'
+  )
+  const layer = await app.activeDocument.activeLayers[0]
+  const old_name = layer.name
+  //change the name of layer to unique name
+  const file_name = layerToFileName(layer, session_id)
+  layer.name = file_name
+  const id = await app.activeDocument.activeLayers[0].id
   const exportCommand = {
     _obj: 'exportSelectionAsFileTypePressed',
     // _target: { _ref: 'layer', _enum: 'ordinal', _value: 'targetEnum' },
-    _target: { _ref: 'layer', _enum: 'ordinal', _value: 'targetEnum',_id:id },
+    _target: { _ref: 'layer', _enum: 'ordinal', _value: 'targetEnum', _id: id },
 
     fileType: 'png',
     quality: 32,
@@ -532,34 +563,32 @@ async function exportPngCommand (session_id) {
     synchronousExecution: true,
     modalBehavior: 'execute'
   })
-  
+
   return result
 }
 
 async function exportPng (session_id) {
-  
-  console.log("exportPng() -> session_id:", session_id)
+  console.log('exportPng() -> session_id:', session_id)
   try {
-    const old_name = await app.activeDocument.activeLayers[0].name 
+    const old_name = await app.activeDocument.activeLayers[0].name
     await executeAsModal(async () => {
-  await exportPngCommand(session_id)
-})
-
-    app.activeDocument.activeLayers[0].name = old_name 
-    //after export rename the layer to it's original name by remove the "_${id}" from the name 
+      await exportPngCommand(session_id)
+    })
+    setTimeout(async () => {console.log("setTimeout() -> old_name: ",old_name)  
+    await executeAsModal(async () => {
+      app.activeDocument.activeLayers[0].name = old_name
+    })
+    
+  }, 3000); 
+    //after export rename the layer to it's original name by remove the "_${id}" from the name
   } catch (e) {
     console.log('exportPng error:', e)
   }
 }
 
-
-
-
-
-
 // await runModalFunction();
-async function setInitImage (layer,session_id) {
-  const sdapi = require("./sdapi")
+async function setInitImage (layer, session_id) {
+  const sdapi = require('./sdapi')
   await exportPng(session_id)
   // image_name = await app.activeDocument.activeLayers[0].name
   image_name = layer.name
@@ -570,8 +599,8 @@ async function setInitImage (layer,session_id) {
   let ini_image_element = document.getElementById('init_image')
   ini_image_element.src = image_src
 }
-async function setInitImageMask (layer,session_id) {
-  const sdapi = require("./sdapi")
+async function setInitImageMask (layer, session_id) {
+  const sdapi = require('./sdapi')
   await exportPng(session_id)
   //get the active layer name
   // image_name = await app.activeDocument.activeLayers[0].name
@@ -605,5 +634,6 @@ module.exports = {
   setInitImage,
   setInitImageMask,
   exportPng,
-  layerToFileName
+  layerToFileName,
+  layerNameToFileName
 }


### PR DESCRIPTION
bug fix: the plugin now export "init images" and "init mask" with unique names to avoid loading old init images into the ui. 