### PR TITLE
Upgrade mechanism to check version, handle subversion issue

### DIFF
--- a/start_server.sh
+++ b/start_server.sh
@@ -11,14 +11,16 @@ fi
 
 # Check the default python version
 orig_ver=$(python -V 2>&1)
-ver=$( echo "$orig_ver" | sed 's/.* \([0-9]\).\([0-9]\).*/\1\2/')
-if [[ "$ver" -gt "37" ]] # Because of uvicorn==0.20.0 in requirements
+major_version=$(echo "$orig_ver" | sed 's/[^0-9]*\([0-9]*\)\..*/\1/')
+minor_subversion=$(echo "$orig_ver" | sed -E 's/^[^.]*\.([^.]*).*$/\1/')
+if [[ "$major_version" -ge "3" ]] && [[ "$minor_subversion" -ge "7" ]] # Because of uvicorn==0.20.0 in requirements
 then
-    echo "You have valid version of ($orig_ver)"
+    echo "You have valid version of $orig_ver"
 else
-    echo "Your version ($orig_ver) not valid, should be >3.7"
+    echo "Your version $orig_ver not valid, should be >=3.7"
     exit 1
 fi
+
 
 # Check if the desired environment exists
 if [ ! -d "server_env" ]; then


### PR DESCRIPTION
Add new way to check version, separate variables for major and minor version, add support for two(or-more) digits in subversion.

Also, executed some tests on different python versions using this snippet:

```
for orig_ver in "Python 2.7.5" "Python 2.8.3" "Python 2.9.0" "Python 3.0.0" "Python 3.1.0" "Python 3.2.0" "Python 3.7.0" "Python 3.9.0" "Python 3.10.1" "Python 3.11.1"
do 
	major_version=$(echo "$orig_ver" | sed 's/[^0-9]*\([0-9]*\)\..*/\1/')
	minor_subversion=$(echo "$orig_ver" | sed -E 's/^[^.]*\.([^.]*).*$/\1/')
	if [[ "$major_version" -ge "3" ]] && [[ "$minor_subversion" -ge "7" ]] # Because of uvicorn==0.20.0 in requirements
	then
	    echo "You have valid version of $orig_ver"
	else
	    echo "Your version $orig_ver not valid, should be >=3.7"
#	    exit 1
	fi
done
```
There is some results:
<img width="451" alt="image" src="https://user-images.githubusercontent.com/42819131/224250450-1e1ae0ea-afe1-4cd7-888e-4c28d197fc33.png">
