### PR TITLE
add batch_count

### DIFF
--- a/index.html
+++ b/index.html
@@ -2198,20 +2198,33 @@
                 <div class="">
                     <div id="batchNumber-steps-container">
                         <div id="batchNumberUi">
-                            <div style="display: flex">
-                                <div id="batchNumberSdUiTabContainer">
-                                    <sp-label>Images:</sp-label
+                            <div style="width: 100%; display: flex; justify-content: space-around;">
+                                <div id="batchNumberSdUiTabContainer" style="width: 35%; display: flex; flex-direction: column; align-items: flex-start">
+                                    <sp-label>Batch Size:</sp-label
                                     ><sp-textfield
+                                        style="width: 100%"
                                         title="the number of images to generate at once.The larger the number more VRAM stable diffusion will use."
-                                        id="tiNumberOfImages"
+                                        id="tiNumberOfBatchSize"
                                         type="number"
                                         placeholder="1"
                                         value="1"
                                     ></sp-textfield>
                                 </div>
-                                <div>
+                                <div id="batchNumberSdUiTabContainer" style="width: 20%; display: flex; flex-direction: column; align-items: flex-start">
+                                    <sp-label>Batch Count:</sp-label
+                                    ><sp-textfield
+                                        style="width: 100%"
+                                        title="the number of images to generate in queue. The larger the number the longer will take."
+                                        id="tiNumberOfBatchCount"
+                                        type="number"
+                                        placeholder="1"
+                                        value="1"
+                                    ></sp-textfield>
+                                </div>
+                                <div style="width: 35%; display: flex; flex-direction: column; align-items: flex-start">
                                     <sp-label>Steps:</sp-label
                                     ><sp-textfield
+                                        style="width: 100%"
                                         title="the higher the steps the longer it will take to generate an image"
                                         id="tiNumberOfSteps"
                                         type="number"

--- a/index.js
+++ b/index.js
@@ -1811,8 +1811,8 @@ async function getSettings() {
         const extension_type = settings_tab.getExtensionType() // get the extension type
         const selectionInfo = await psapi.getSelectionInfoExe()
         payload['selection_info'] = selectionInfo
-        const numberOfImages = parseInt(
-            document.querySelector('#tiNumberOfImages').value
+        const numberOfBatchSize = parseInt(
+            document.querySelector('#tiNumberOfBatchSize').value
         )
         const numberOfSteps = document.querySelector('#tiNumberOfSteps').value
         const prompt = html_manip.getPrompt()
@@ -1999,7 +1999,7 @@ async function getSettings() {
             width: width,
             height: height,
             denoising_strength: denoising_strength,
-            batch_size: numberOfImages,
+            batch_size: numberOfBatchSize,
             cfg_scale: cfg_scale,
             seed: seed,
             mask_blur: mask_blur,
@@ -2575,7 +2575,11 @@ Array.from(document.getElementsByClassName('btnGenerateClass')).forEach(
     (btn) => {
         btn.addEventListener('click', async (evt) => {
             tempDisableElement(evt.target, 5000)
-            await easyModeGenerate(g_sd_mode)
+            const numberOfBatchCount = parseInt(
+                document.querySelector('#tiNumberOfBatchCount').value
+            )
+            for (let i = 0; i < numberOfBatchCount; i++)
+                await easyModeGenerate(g_sd_mode)
         })
     }
 ) //REFACTOR: move to events.js


### PR DESCRIPTION
Just like what `batch count` in SD webui does: generate images in sequence. So I can start a generating with large batch count, and go to do some another work.

I found that you are planning to refactor the UI, so I didn't change the progress behaviour. I think it will make the code more unreadable after implement the progress with `batch count`, unless we use some global data store.