### PR TITLE
[bugfix] when maxcontrolnet is more than 1 but only one CN is enabled

### DIFF
--- a/utility/tab/control_net.js
+++ b/utility/tab/control_net.js
@@ -360,25 +360,24 @@ function mapPluginSettingsToControlNet(plugin_settings) {
     // debugger
     let active_index = 0
     for (let index = 0; index < g_controlnet_max_supported_models; index++) {
-        if (getEnableControlNet(index)) {
-            controlnet_units[active_index] = {
-                input_image: g_generation_session.controlNetImage[index],
-                mask: '',
-                module: getSelectedModule(index),
-                model: getSelectedModel(index),
-                weight: getWeight(index),
-                resize_mode: 'Scale to Fit (Inner Fit)',
-                lowvram: getUseLowVram(index),
-                processor_res: 512,
-                threshold_a: 64,
-                threshold_b: 64,
-                // guidance: ,
-                guidance_start: getControlNetWeightGuidanceStrengthStart(index),
-                guidance_end: getControlNetWeightGuidanceStrengthEnd(index),
-                guessmode: false,
-            }
-            active_index++
+        controlnet_units[active_index] = {
+            enabled: getEnableControlNet(index),
+            input_image: g_generation_session.controlNetImage[index],
+            mask: '',
+            module: getSelectedModule(index),
+            model: getSelectedModel(index),
+            weight: getWeight(index),
+            resize_mode: 'Scale to Fit (Inner Fit)',
+            lowvram: getUseLowVram(index),
+            processor_res: 512,
+            threshold_a: 64,
+            threshold_b: 64,
+            // guidance: ,
+            guidance_start: getControlNetWeightGuidanceStrengthStart(index),
+            guidance_end: getControlNetWeightGuidanceStrengthEnd(index),
+            guessmode: false,
         }
+        active_index++
     }
 
     if (


### PR DESCRIPTION
This bug can be reproduce in ControlNet 1.1.
To fix it, We have to pass as many CN config as the MaxControlNet to the api. Otherwise a error will be raised.

```
API error: POST: http://xxxxxxxxxxxxxx/sdapi/v1/img2img {'error': 'AttributeError', 'detail': '', 'body': '', 'errors': "'str' object has no attribute 'enabled'"}
```

------
ControlNet 1.0 is tested. Work fine.