### PR TITLE
some controlnet fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -1143,6 +1143,7 @@
                                 show-value="true"
                                 id="slControlNetProcessorRes_0"
                                 class="slControlNetProcessorRes_"
+                                style="display:none"
                                 min="64"
                                 max="2048"
                                 value="512"
@@ -1162,6 +1163,7 @@
                             <sp-slider
                                 show-value="false"
                                 class="slControlNetThreshold_A_"
+                                style="display:none"
                                 min="0"
                                 max="100"
                                 value="50"
@@ -1182,6 +1184,7 @@
                             <sp-slider
                                 show-value="false"
                                 class="slControlNetThreshold_B_"
+                                style="display:none"
                                 min="0"
                                 max="100"
                                 value="50"

--- a/utility/tab/control_net.js
+++ b/utility/tab/control_net.js
@@ -378,7 +378,7 @@ function changeModule(_module, index) {
         threshold_a_element.dataset['sd_max'] = params.threshold_a.max
         ControlNetUnit.setThreshold(index, 'a', params.threshold_a.value)
         threshold_a_element.style.display = 'block'
-        threshold_a_label_element.innerText = params.threshold_a.name
+        threshold_a_label_element.innerText = params.threshold_a.name + ":"
     } else {
         ControlNetUnit.setThreshold(index, 'a', 32)
         threshold_a_element.style.display = 'none'
@@ -394,7 +394,7 @@ function changeModule(_module, index) {
         threshold_b_element.dataset['sd_max'] = params.threshold_b.max
         ControlNetUnit.setThreshold(index, 'b', params.threshold_b.value)
         threshold_b_element.style.display = 'block'
-        threshold_b_label_element.innerText = params.threshold_b.name
+        threshold_b_label_element.innerText = params.threshold_b.name + ":"
     } else {
         ControlNetUnit.setThreshold(index, 'b', 32)
         threshold_b_element.style.display = 'none'

--- a/utility/tab/control_net.js
+++ b/utility/tab/control_net.js
@@ -291,7 +291,7 @@ async function requestControlNetModuleList() {
     // const module_list = g_sd_config_obj.getControlNetPreprocessors()
 
     const result = await api.requestGet(
-        `${g_sd_url}/controlnet/module_list?alias_names=false`
+        `${g_sd_url}/controlnet/module_list?alias_names=1`
     )
 
     return result?.module_list
@@ -1088,7 +1088,7 @@ async function initializeControlNetTab(controlnet_max_models) {
             parent_container.appendChild(controlnet_unit)
         }
 
-        const full_url = `${g_sd_url}/controlnet/module_list?alias_names=false`
+        const full_url = `${g_sd_url}/controlnet/module_list?alias_names=1`
         let result_json = await api.requestGet(full_url)
         g_module_detail = result_json['module_detail']
 


### PR DESCRIPTION
fix:
1. uneccessary thresholdA/B display by default
2. a missing ':' after threshold A/B
3. did not use the alias name for controlnet preprocessor which is used in Auto1111