### PR TITLE
hide model picker when preprocessor is reference

### DIFF
--- a/sdapi_py_re.js
+++ b/sdapi_py_re.js
@@ -603,7 +603,7 @@ async function requestControlNetTxt2Img(plugin_settings) {
             app.showAlert('you need to select a valid ControlNet Module')
             throw 'you need to select a valid ControlNet Module'
         }
-        if (!control_net_settings['controlnet_units'][index]['model']) {
+        if (!control_net_settings['controlnet_units'][index]['model'] && !control_net.getModuleDetail()[control_net_settings['controlnet_units'][index]['module']].model_free) {
             app.showAlert('you need to select a valid ControlNet Model')
             throw 'you need to select a valid ControlNet Model'
         }
@@ -684,7 +684,7 @@ async function requestControlNetImg2Img(plugin_settings) {
             app.showAlert('you need to select a valid ControlNet Module')
             throw 'you need to select a valid ControlNet Module'
         }
-        if (!control_net_settings['controlnet_units'][index]['model']) {
+        if (!control_net_settings['controlnet_units'][index]['model'] && !control_net.getModuleDetail()[control_net_settings['controlnet_units'][index]['module']].model_free) {
             app.showAlert('you need to select a valid ControlNet Model')
             throw 'you need to select a valid ControlNet Model'
         }

--- a/utility/tab/control_net.js
+++ b/utility/tab/control_net.js
@@ -1138,4 +1138,7 @@ module.exports = {
     ControlNetUnit,
     populateControlNetPresetMenu,
     isControlNetModeEnable,
+    getModuleDetail() {
+        return g_module_detail
+    }
 }

--- a/utility/tab/control_net.js
+++ b/utility/tab/control_net.js
@@ -349,10 +349,23 @@ function changeModule(_module, index) {
         return obj
     }
     const params = remapArray(detail['sliders'])
+    const model_free = detail.model_free
 
     // threshold_a_element.min = prams.
     //     threshold_a_element.max =
     // debugger
+    if (model_free)
+        controlnetElement(
+            index,
+            '.mModelsMenuControlNet_'
+        ).parentElement.style.display = 'none'
+
+    else
+        controlnetElement(
+            index,
+            '.mModelsMenuControlNet_'
+        ).parentElement.style.display = 'block'
+
 
     if (params?.preprocessor_res) {
         const preprocessor_res_label_element = controlnetElement(


### PR DESCRIPTION
compat the new preprocessor `reference`
https://github.com/Mikubill/sd-webui-controlnet/pull/1370