### PR TITLE
Update python_replacement.js to fix first run prompts library

### DIFF
--- a/utility/sdapi/python_replacement.js
+++ b/utility/sdapi/python_replacement.js
@@ -393,6 +393,12 @@ async function loadPromptShortcut(file_name) {
             return json
         }
     } catch (e) {
+        const file = await folder.createFile('prompt_shortcut.json', {type: storage.types.file, overwrite: true});
+        if (file.isFile) {
+            await file.write('{}', {append: false});
+            data = {};
+            return file;
+        }
         console.warn(e)
         return {}
     }


### PR DESCRIPTION
If you are first time to run prompts library, you will always use template because you didn't have file in the uxp storage DataFolder.