### PR TITLE
Fix sp-tab-page scrolling bugs.

### DIFF
--- a/index.html
+++ b/index.html
@@ -340,30 +340,11 @@
         }
 
         .sp-tab-page {
-            visibility: hidden;
-            /* display: none; */
-            flex: 1 1 auto;
-            /* overflow: scroll; */
-            overflow-y: scroll;
-            padding: 12px 0;
+            display: none;
+            padding: 10px 0;
             flex-direction: column;
-        }
-
-        .sp-tab-page.visible-hack {
-            display: flex;
-            /* overflow: hidden; */
-            /* overflow-y: scroll; */
-            /* position: fixed; */
-            top: 25px;
-            visibility: visible;
             max-width: 100%;
-            width: 100%;
-            /* margin: 0px; */
-            position: absolute;
-            width: 100%;
-            left: 0;
-            padding-left: 10px;
-            padding-right: 10px;
+            position: relative;
         }
 
         .sp-tab-page.visible {
@@ -1124,7 +1105,7 @@
             </div>
 
             <div
-                class="sp-tab-page visible-hack"
+                class="sp-tab-page visible"
                 id="sp-stable-diffusion-ui-tab-page"
             >
                 <div id="sdTabContainer"></div>

--- a/index.html
+++ b/index.html
@@ -341,7 +341,7 @@
 
         .sp-tab-page {
             display: none;
-            padding: 10px 0;
+            padding: 7px;
             flex-direction: column;
             max-width: 100%;
             position: relative;

--- a/index.js
+++ b/index.js
@@ -313,9 +313,9 @@ Array.from(document.querySelectorAll('.sp-tab')).forEach((theTab) => {
                             .getAttribute('id')
                             .startsWith(theTab.getAttribute('id'))
                     ) {
-                        tabPage.classList.add('visible-hack')
+                        tabPage.classList.add('visible')
                     } else {
-                        tabPage.classList.remove('visible-hack')
+                        tabPage.classList.remove('visible')
                     }
                 }
             )


### PR DESCRIPTION
Resolves #409 

The primary issue here was that both `.wrapper` and `.sd-tab-page` were considered scrollable. `.wrapper` is bound to the panel window height, and would become scrollable when the contents overflowed.

however `.sd-tab-page` was unbound. It grows instead of overflowing, but it would still capture scroll events and block them from bubbling up to `.wrapper`. So the only way you could scroll the page was by hovering over anything that was not `.sd-tab-page` (the scrollbar, or after the end of the content on any page.)

This fix restores `display: none`, which works fine, and commits to `.wrapper` being the scrollable element. I also removed some unnecessary styles on `.sd-tab-page` that weren't doing what we thought they were doing.